### PR TITLE
remove custom devDependency rules for no-extraneous-dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,12 +18,6 @@ module.exports = {
     'import/prefer-default-export': 'off',
     'no-plusplus': 'off',
     'import/extensions': 'off',
-    'import/no-extraneous-dependencies': [
-      'error',
-      {
-        devDependencies: ['**/tests/**', '**/*.test.js', '**/*.spec.js'],
-      },
-    ],
     'react/no-multi-comp': [
       'error',
       {


### PR DESCRIPTION
This rules has a great default in the AirBnb base config and from my perspective it is not necessary to restrict it that hard.